### PR TITLE
Fix issue #364

### DIFF
--- a/template/comment_list.tpl
+++ b/template/comment_list.tpl
@@ -10,6 +10,7 @@
 {/html_style}{/strip}
 {footer_script}var error_icon = "{$ROOT_URL}{$themeconf.icon_dir}/errors_small.png";{/footer_script}
 {/if}
+{if isset($comments)}
 <div id="commentList">
 {foreach from=$comments item=comment name=comment_loop}
     <div class="comment">
@@ -85,3 +86,4 @@
     </div>
 {/foreach}
 </div>
+{/if}


### PR DESCRIPTION
When no comments exist, PHP throws warning when properties of $comment are referenced. bracketed template code with if isset ($comments). Suspect this is a PHP 8.0-8.1 update issue.