### PR TITLE
Don't show thumbnail video symbol for HEIC photos

### DIFF
--- a/template/index.tpl
+++ b/template/index.tpl
@@ -27,7 +27,7 @@
             <span class="pwg-button-text">{'Search in this set'|translate}</span>
         </a>
     </li>
-{/if}                
+{/if}
 {if !empty($image_orders)}
                     <li class="nav-item dropdown">
                         <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" title="{'Sort order'|@translate}">
@@ -307,7 +307,7 @@ $(document).ajaxComplete(function() {
   addVideoIndicator();
 });
 {else}
-$('.card-thumbnail').find('img[src*="pwg_representative"]').each(function() {
+$('.card-thumbnail:not(.file-ext-heic)').find('img[src*="pwg_representative"]').each(function() {
   $(this).closest('div').append('<i class="fas fa-file-video fa-2x video-indicator" aria-hidden="true" style="position: absolute; top: 10px; left: 10px; z-index: 100; color: #fff;"></i>');
 });
 {/if}


### PR DESCRIPTION
Since [Piwigo 14's HEIC support](https://piwigo.com/blog/2023/09/13/get-a-sneak-preview-of-piwigo-14/), HEIC thumbnails show a video symbol:

![image](https://github.com/Piwigo/piwigo-bootstrap-darkroom/assets/17737/98b35a3d-c28c-41b3-9caf-f881701b3334)

That seems to be because they have `pwg_representitive` files which, like videos, they require to be rendered in all browsers.

https://github.com/Piwigo/piwigo-bootstrap-darkroom/blob/012aeb692f347b942024d0e95556041437d57165/template/index.tpl#L310-L312

This PR excludes thumbnail cards with a `file-ext-heic` class:

![image](https://github.com/Piwigo/piwigo-bootstrap-darkroom/assets/17737/3f22e942-56d1-4ee0-bb7f-fe8fd83fc09f)
